### PR TITLE
fix parsing status line for curl and wget

### DIFF
--- a/lib/HTTP/Tinyish/Base.pm
+++ b/lib/HTTP/Tinyish/Base.pm
@@ -41,7 +41,7 @@ sub parse_http_header {
         }
     }
 
-    my($proto, $status, $reason) = split / /, $status_line;
+    my($proto, $status, $reason) = split / /, $status_line, 3;
     return unless $proto and $proto =~ /^HTTP\/(\d+)\.(\d+)$/i;
 
     $res->{status} = $status;

--- a/t/tinyish.t
+++ b/t/tinyish.t
@@ -91,6 +91,7 @@ for my $backend (@backends) {
 
     $res = HTTP::Tinyish->new->get("http://httpbin.org/status/404");
     is $res->{status}, 404;
+    is $res->{reason}, "NOT FOUND";
 
     $res = HTTP::Tinyish->new->get("http://httpbin.org/response-headers?Foo=Bar+Baz");
     is $res->{headers}{foo}, "Bar Baz";


### PR DESCRIPTION
If status line contains spaces in "reason" section, curl and wget backends cannot parse it correctly.
This PR fixes it.
