### PR TITLE
Fix HTTP::Tinyish::LWP 304 handling

### DIFF
--- a/lib/HTTP/Tinyish/LWP.pm
+++ b/lib/HTTP/Tinyish/LWP.pm
@@ -80,7 +80,7 @@ sub mirror {
     return {
         url     => $url,
         content => $res->decoded_content,
-        success => $res->is_success,
+        success => $res->is_success || $res->code == 304,
         status  => $res->code,
         reason  => $res->message,
         headers => $self->_headers_to_hashref($res->headers),

--- a/t/tinyish.t
+++ b/t/tinyish.t
@@ -84,6 +84,7 @@ for my $backend (@backends) {
         skip "Wget doesn't handle mirror", 1 if $backend =~ /Wget/;
         $res = HTTP::Tinyish->new->mirror("http://www.cpan.org", $fn);
         is $res->{status}, 304;
+        ok $res->{success};
     }
 
     $res = HTTP::Tinyish->new(agent => "Menlo/1")->get("http://httpbin.org/user-agent");


### PR DESCRIPTION
HTTP::Tiny::mirror() returns success when status code = 304.
https://github.com/chansen/p5-http-tiny/blob/master/lib/HTTP/Tiny.pm#L297

So I think HTTP::Tinyish::LWP::mirror() should follow that.
