### PR TITLE
Accept server protocol HTTP/2

### DIFF
--- a/lib/HTTP/Tinyish/Base.pm
+++ b/lib/HTTP/Tinyish/Base.pm
@@ -42,7 +42,7 @@ sub parse_http_header {
     }
 
     my($proto, $status, $reason) = split / /, $status_line, 3;
-    return unless $proto and $proto =~ /^HTTP\/(\d+)\.(\d+)$/i;
+    return unless $proto and $proto =~ /^HTTP\/(\d+)(\.(\d+))?$/i;
 
     $res->{status} = $status;
     $res->{reason} = $reason;


### PR DESCRIPTION
If curl is compiled with `--with-http2`, then HTTP::Tinyish::Curl does not create a response hash properly (which means it does not contain "status", "success", "headers", and "reason" field).
```
> curl --version
curl 7.50.3 (x86_64-apple-darwin15.6.0) libcurl/7.50.3 OpenSSL/1.0.2j zlib/1.2.8 nghttp2/1.15.0
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
Features: IPv6 Largefile NTLM NTLM_WB SSL libz TLS-SRP HTTP2 UnixSockets

> cat test.pl
use strict;
use HTTP::Tinyish;
use Data::Dumper;
$HTTP::Tinyish::PreferredBackend = qw(HTTP::Tinyish::Curl);
my $url = "https://h2o.examp1e.net";
my $res = HTTP::Tinyish->new->get($url);
print Dumper $res;

> perl test.pl
$VAR1 = {
          'url' => 'https://h2o.examp1e.net',
          'content' => '<!DOCTYPE html> ...'
        };
```

An easy fix will be to accept "HTTP/2" as `$proto`.

Note:
* A dump-header file is here. https://gist.github.com/skaji/318811cc74997c59051a8f4abe131774
* Because HTTP::Tiny is an **HTTP/1.1** client, we might execute curl with `--http1.1` option.
