### PR TITLE
take care of redirects when server protocol is HTTP/2

### DIFF
--- a/lib/HTTP/Tinyish/Base.pm
+++ b/lib/HTTP/Tinyish/Base.pm
@@ -19,7 +19,7 @@ sub parse_http_header {
     my($self, $header, $res) = @_;
 
     # it might have multiple headers in it because of redirects
-    $header =~ s/.*^(HTTP\/\d\.\d )/$1/ms;
+    $header =~ s/.*^(HTTP\/\d(?:\.\d)?)/$1/ms;
 
     # grab the first chunk until the line break
     if ($header =~ /^(.*?\x0d?\x0a\x0d?\x0a)/) {


### PR DESCRIPTION
I'm sorry, but #4 does not take care of redirects. This PR fixes that.
 
```
> curl -sS -o /dev/null --dump-header dump.txt https://google.com
> cat dump.txt
HTTP/2 302
cache-control: private
content-type: text/html; charset=UTF-8
location: https://www.google.co.jp/?gfe_rd=cr&ei=YtIvWJu2OrLf8AeowpD4Aw
content-length: 262
date: Sat, 19 Nov 2016 04:17:38 GMT
alt-svc: quic=":443"; ma=2592000; v="36,35,34"

HTTP/2 200
date: Sat, 19 Nov 2016 04:17:39 GMT
expires: -1
cache-control: private, max-age=0
content-type: text/html; charset=Shift_JIS
p3p: CP="This is not a P3P policy! See https://www.google.com/support/accounts/answer/151657?hl=en for more info."
server: gws
x-xss-protection: 1; mode=block
x-frame-options: SAMEORIGIN
set-cookie: NID=91=MrLp4Rj2NipKbk8B3w6uaSyoTk85w2KOotpF6eBsEAiL-XUVTTz4osq_jXF6eahX4hVm73oc5F9rLDlYxnsa44-XLoTmDMU5iBIusLcWbRn2UFVjNC4AOyx3aC4qdhD-; expires=Sun, 21-May-2017 04:17:39 GMT; path=/; domain=.google.co.jp; HttpOnly
alt-svc: quic=":443"; ma=2592000; v="36,35,34"
accept-ranges: none
vary: Accept-Encoding

```

before
```
> git checkout master
> perl -Ilib -MHTTP::Tinyish -MData::Dumper -e '$HTTP::Tinyish::PreferredBackend = ("HTTP::Tinyish::Curl"); my $res = HTTP::Tinyish->new->get(shift); delete $res->{content}; print Dumper $res' https://google.com
$VAR1 = {
          'url' => 'https://google.com',
          'headers' => {
                         'content-length' => '262',
                         'location' => 'https://www.google.co.jp/?gfe_rd=cr&ei=VdMvWLHqEq_f8AfxrrWwCw',
                         'content-type' => 'text/html; charset=UTF-8',
                         'alt-svc' => 'quic=":443"; ma=2592000; v="36,35,34"',
                         'cache-control' => 'private',
                         'date' => 'Sat, 19 Nov 2016 04:21:41 GMT'
                       },
          'status' => '302',
          'reason' => '',
          'success' => ''
        };
```
after
```
> git checkout accept-http2-again
> perl -Ilib -MHTTP::Tinyish -MData::Dumper -e '$HTTP::Tinyish::PreferredBackend = ("HTTP::Tinyish::Curl"); my $res = HTTP::Tinyish->new->get(shift); delete $res->{content}; print Dumper $res' https://google.com
$VAR1 = {
          'reason' => '',
          'success' => 1,
          'headers' => {
                         'set-cookie' => 'NID=91=cjHMtxi7JqF4x8ronUhhOjKoW0QskEgVZHl5yuPtCJ1VxF-Fdbw3ZnWvkUTp3FeWawuKSlWe5GFXHdOI9OwlBjN9bj0iRirkwE4rkNTKSV-E27FRyZbTRjIEQQiIprJ4; expires=Sun, 21-May-2017 04:22:13 GMT; path=/; domain=.google.co.jp; HttpOnly',
                         'alt-svc' => 'quic=":443"; ma=2592000; v="36,35,34"',
                         'date' => 'Sat, 19 Nov 2016 04:22:13 GMT',
                         'x-xss-protection' => '1; mode=block',
                         'content-type' => 'text/html; charset=Shift_JIS',
                         'p3p' => 'CP="This is not a P3P policy! See https://www.google.com/support/accounts/answer/151657?hl=en for more info."',
                         'accept-ranges' => 'none',
                         'expires' => '-1',
                         'cache-control' => 'private, max-age=0',
                         'x-frame-options' => 'SAMEORIGIN',
                         'server' => 'gws',
                         'vary' => 'Accept-Encoding'
                       },
          'url' => 'https://google.com',
          'status' => '200'
        };
```