### PR TITLE
unlink tempfiles

### DIFF
--- a/lib/HTTP/Tinyish/Curl.pm
+++ b/lib/HTTP/Tinyish/Curl.pm
@@ -47,7 +47,7 @@ sub request {
     my($self, $method, $url, $opts) = @_;
     $opts ||= {};
 
-    my(undef, $temp) = File::Temp::tempfile;
+    my(undef, $temp) = File::Temp::tempfile(UNLINK => 1);
 
     my($output, $error);
     eval {
@@ -74,7 +74,7 @@ sub mirror {
     my($self, $url, $file, $opts) = @_;
     $opts ||= {};
 
-    my(undef, $temp) = File::Temp::tempfile;
+    my(undef, $temp) = File::Temp::tempfile(UNLINK => 1);
 
     my $output;
     eval {


### PR DESCRIPTION
Currently HTTP::Tinyish::Curl leaves tempfiles.

```
> cat test.pl
#!/usr/bin/env perl
use strict;
use HTTP::Tinyish;
$HTTP::Tinyish::PreferredBackend = "HTTP::Tinyish::Curl";
HTTP::Tinyish->new->get("http://www.cpan.org");

> TMPDIR=$PWD perl test.pl

> ls
2U3aNoN34P  test.pl

> cat 2U3aNoN34P
HTTP/1.1 200 OK
Server: Apache/2.2.15 (Red Hat)
Last-Modified: Mon, 02 Jan 2017 12:18:02 GMT
ETag: "165c09-2061-5451b8affb280"
...
```

This PR adds UNLINK => 1 to File::Temp::tempfile to make sure tempfiles are unlinked.