### PR TITLE
use HTTP::Tiny->can_ssl to detect SSL support

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -3,7 +3,7 @@ requires 'perl', '5.008005';
 requires 'parent';
 requires 'File::Which';
 requires 'IPC::Run3';
-requires 'HTTP::Tiny', 0.054;
+requires 'HTTP::Tiny', 0.055;
 
 on test => sub {
     requires 'Test::More', '0.96';

--- a/lib/HTTP/Tinyish/HTTPTiny.pm
+++ b/lib/HTTP/Tinyish/HTTPTiny.pm
@@ -8,9 +8,7 @@ my %supports = (http => 1);
 sub configure {
     my %meta = ("HTTP::Tiny" => $HTTP::Tiny::VERSION);
 
-    if (eval { HTTP::Tiny::Handle->_assert_ssl; 1 }) {
-        $supports{https} = 1;
-    }
+    $supports{https} = HTTP::Tiny->can_ssl;
 
     \%meta;
 }


### PR DESCRIPTION
You implemented this :)

cf
* https://github.com/chansen/p5-http-tiny/pull/70
* https://metacpan.org/source/DAGOLDEN/HTTP-Tiny-0.070/Changes#L114