### PR TITLE
Fix test

### DIFF
--- a/t/tinyish.t
+++ b/t/tinyish.t
@@ -49,7 +49,7 @@ for my $backend (@backends) {
     is_deeply decode_json($res->{content})->{form}, { foo => "1", bar => "2" };
 
  SKIP: {
-        skip "HTTP::Tiny's chunked upload is not supported by httpbin.", 1 if $backend =~ /HTTPTiny/;
+        skip "HTTP::Tiny's and LWP's chunked uploads are not supported by httpbin.", 1 if $backend =~ /HTTPTiny|LWP/;
         my @data = ("xyz\n", "xyz");
         $res = HTTP::Tinyish->new(timeout => 1)->post("http://httpbin.org/post", {
             headers => { 'Content-Type' => 'application/octet-stream' },

--- a/t/tinyish.t
+++ b/t/tinyish.t
@@ -72,7 +72,10 @@ for my $backend (@backends) {
 
     $res = HTTP::Tinyish->new(default_headers => { "Foo" => "Bar", Dnt => "1" })
       ->get("http://httpbin.org/headers", { headers => { "Foo" => ["Bar", "Baz"] } });
-    is decode_json($res->{content})->{headers}{Foo}, "Bar,Baz";
+ SKIP: {
+        skip "httpbin does not support multiple headers", 1;
+        is decode_json($res->{content})->{headers}{Foo}, "Bar,Baz";
+    }
     is decode_json($res->{content})->{headers}{Dnt}, "1";
 
     my $fn = tempdir(CLEANUP => 1) . "/index.html";


### PR DESCRIPTION
This PR fixes test.

(a) Now, not only HTTP::Tiny's, but also LWP's chunked upload is not supported by httpbin.
So skip LWP test too. b566aef
```
❯ prove -l t
t/tinyish.t .. # Testing with HTTP::Tinyish::LWP
t/tinyish.t .. 8/?
#   Failed test at t/tinyish.t line 58.
#          got: '503'
#     expected: '200'
malformed JSON string, neither array, object, number, string or atom, at character offset 0 (before "<!DOCTYPE html>\n\t<...") at t/tinyish.t line 59.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 255 just after 10.
t/tinyish.t .. Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 1/10 subtests
```

(b) httpbin does not support multiple headers anymore.
So skip multiple header test. d1b390d
```
❯ prove -l t
t/tinyish.t .. # Testing with HTTP::Tinyish::LWP
t/tinyish.t .. 13/?
#   Failed test at t/tinyish.t line 75.
#          got: 'Baz'
#     expected: 'Bar,Baz'
t/tinyish.t .. 29/? # Testing with HTTP::Tinyish::HTTPTiny
t/tinyish.t .. 40/?
#   Failed test at t/tinyish.t line 75.
#          got: 'Baz'
#     expected: 'Bar,Baz'
t/tinyish.t .. 58/? # Testing with HTTP::Tinyish::Curl
t/tinyish.t .. 70/?
#   Failed test at t/tinyish.t line 75.
#          got: 'Baz'
#     expected: 'Bar,Baz'
t/tinyish.t .. 88/? # Testing with HTTP::Tinyish::Wget
t/tinyish.t .. 116/? # Looks like you failed 3 tests of 117.
t/tinyish.t .. Dubious, test returned 3 (wstat 768, 0x300)
Failed 3/117 subtests
	(less 3 skipped subtests: 111 okay)

Test Summary Report
-------------------
t/tinyish.t (Wstat: 768 Tests: 117 Failed: 3)
  Failed tests:  13, 42, 72
  Non-zero exit status: 3
Files=1, Tests=117, 42 wallclock secs ( 0.04 usr  0.01 sys +  0.99 cusr  0.44 csys =  1.48 CPU)
Result: FAIL
```