### PR TITLE
make curl->mirror return internal_error if exit status != 0

### DIFF
--- a/lib/HTTP/Tinyish/Curl.pm
+++ b/lib/HTTP/Tinyish/Curl.pm
@@ -89,7 +89,7 @@ sub mirror {
         ], \undef, \$output, \undef;
     };
 
-    if ($@) {
+    if ($@ or $?) {
         return $self->internal_error($url, $@);
     }
 


### PR DESCRIPTION
Currently HTTP::Tinyish::Curl's mirror method returns `{ success => 1 }` even if exit status != 0.
According to https://ec.haxx.se/usingcurl-returns.html,
for example, if timeout occur, curl exits with 28.
So I think HTTP::Tinyish::Curl's mirror method should return internal_error if curl exit status != 0.

P.S.
You look like you intentionally skip $? check. Then could you explain why? Thanks! 