### PR TITLE
append --show-error to the curl command

### DIFF
--- a/lib/HTTP/Tinyish/Curl.pm
+++ b/lib/HTTP/Tinyish/Curl.pm
@@ -104,6 +104,7 @@ sub build_options {
     my @options = (
         '--location',
         '--silent',
+        '--show-error',
         '--max-time', ($self->{timeout} || 60),
         '--max-redirs', ($self->{max_redirect} || 5),
         '--user-agent', ($self->{agent} || "HTTP-Tinyish/$HTTP::Tinyish::VERSION"),


### PR DESCRIPTION
If we execute curl with `--show-error` option,
then it shows error to STDERR when errors occur
so that we can get the error detail in `$res->{content}`.

I think this is useful. 

before
```
❯ perl -Ilib -MHTTP::Tinyish -MDDP -e '$HTTP::Tinyish::PreferredBackend = "HTTP::Tinyish::Curl"; my $res = HTTP::Tinyish->new->get("http://example.invalid"); p $res'
\ {
    content   "",
    headers   {
        content-length   0,
        content-type     "text/plain"
    },
    reason    "Internal Exception",
    status    599,
    success   "",
    url       "http://example.invalid"
}
```

after
```
❯ perl -Ilib -MHTTP::Tinyish -MDDP -e '$HTTP::Tinyish::PreferredBackend = "HTTP::Tinyish::Curl"; my $res = HTTP::Tinyish->new->get("http://example.invalid"); p $res'
\ {
    content   "curl: (6) Could not resolve host: example.invalid
",
    headers   {
        content-length   50,
        content-type     "text/plain"
    },
    reason    "Internal Exception",
    status    599,
    success   "",
    url       "http://example.invalid"
}
```