### PR TITLE
Fix t/tinyish.t when no backend is tested

### DIFF
--- a/t/tinyish.t
+++ b/t/tinyish.t
@@ -22,7 +22,12 @@ my @backends = $ENV{TEST_BACKEND}
 for my $backend (@backends) {
     $HTTP::Tinyish::PreferredBackend = $backend;
     my $config = HTTP::Tinyish->configure_backend($backend);
-    next unless $config && $backend->supports('http');
+    my $can_test_backend = $config && $backend->supports('http');
+    SKIP: {
+        skip "Testing backend $backend", 1 unless $can_test_backend;
+        pass "Testing backend $backend";
+    }
+    next unless $can_test_backend;
 
     diag "Testing with $backend";
 
@@ -97,7 +102,7 @@ for my $backend (@backends) {
         ok $res->{success};
     }
 
-    my $fn = tempdir(CLEANUP => 1) . "/index.html";
+    $fn = tempdir(CLEANUP => 1) . "/index.html";
     $res = HTTP::Tinyish->new->mirror("http://example.invalid", $fn);
     is $res->{status}, 599;
     ok !$res->{success};


### PR DESCRIPTION
When skipping all backends the test exit with
fail status.

Adding a dummy 'pass' test could also avoid it.
The SKIP is more about the for loop for backend
but adding it this way make it easier to manage
and see what is tested.

This is fixing an issue noticed on Travis CI when
no backend can be tested.