### PR TITLE
support max_redirect 0

### DIFF
--- a/lib/HTTP/Tinyish/Curl.pm
+++ b/lib/HTTP/Tinyish/Curl.pm
@@ -102,13 +102,14 @@ sub build_options {
     my($self, $url, $opts) = @_;
 
     my @options = (
-        '--location',
         '--silent',
         '--show-error',
         '--max-time', ($self->{timeout} || 60),
-        '--max-redirs', ($self->{max_redirect} || 5),
         '--user-agent', ($self->{agent} || "HTTP-Tinyish/$HTTP::Tinyish::VERSION"),
     );
+    if (my $max_redirect = exists $self->{max_redirect} ? $self->{max_redirect} : 5) {
+        push @options, '--location', '--max-redirs', $max_redirect;
+    }
 
     my %headers;
     if ($self->{default_headers}) {

--- a/lib/HTTP/Tinyish/LWP.pm
+++ b/lib/HTTP/Tinyish/LWP.pm
@@ -103,7 +103,7 @@ sub translate_lwp {
     $agent->parse_head(0);
     $agent->env_proxy;
     $agent->timeout(delete $attr{timeout} || 60);
-    $agent->max_redirect(delete $attr{max_redirect} || 5);
+    $agent->max_redirect(exists $attr{max_redirect} ? $attr{max_redirect} : 5);
     $agent->agent(delete $attr{agent} || "HTTP-Tinyish/$HTTP::Tinyish::VERSION");
 
     # LWP default is to verify, HTTP::Tiny isn't

--- a/lib/HTTP/Tinyish/Wget.pm
+++ b/lib/HTTP/Tinyish/Wget.pm
@@ -117,7 +117,7 @@ sub build_options {
         '--server-response',
         '--timeout', ($self->{timeout} || 60),
         '--tries', 1,
-        '--max-redirect', ($self->{max_redirect} || 5),
+        '--max-redirect', (exists $self->{max_redirect} ? $self->{max_redirect} : 5),
         '--user-agent', ($self->{agent} || "HTTP-Tinyish/$HTTP::Tinyish::VERSION"),
     );
 

--- a/t/tinyish.t
+++ b/t/tinyish.t
@@ -139,6 +139,9 @@ for my $backend (@backends) {
         is $res->{status}, 200;
     }
 
+    $res = HTTP::Tinyish->new(max_redirect => 0)->get("http://httpbin.org/redirect/1");
+    is $res->{status}, 302;
+
     $res = HTTP::Tinyish->new(max_redirect => 2)->get("http://httpbin.org/redirect/3");
     isnt $res->{status}, 200; # either 302 or 599
 


### PR DESCRIPTION
I sometimes want a HTTP client that does not follow redirects.

Because HTTP::Tiny already supports this by specifying `max_redirect => 0`,
it's nice HTTP::Tinyish also supports this by specifying `max_redirect => 0`.