### PR TITLE
Don't mess up downloaded content on Windows

### DIFF
--- a/lib/HTTP/Tinyish/Curl.pm
+++ b/lib/HTTP/Tinyish/Curl.pm
@@ -58,7 +58,11 @@ sub request {
             $self->build_options($url, $opts),
             '--dump-header', $temp,
             $url,
-        ], \undef, \$output, \$error;
+        ], \undef, \$output, \$error,
+        {
+            binmode_stdout => ":raw",
+            binmode_stderr => ":raw",
+        };
     };
 
     if ($@ or $?) {
@@ -86,7 +90,11 @@ sub mirror {
             '--dump-header', $temp,
             '--remote-time',
             $url,
-        ], \undef, \$output, \$error;
+        ], \undef, \$output, \$error,
+        {
+            binmode_stdout => ":raw",
+            binmode_stderr => ":raw",
+        };
     };
 
     if ($@ or $?) {


### PR DESCRIPTION
Set curl STDIN/OUT to :raw, otherwise the CRLF -> LF conversion will mess up the contents.