### PR TITLE
unlink empty file on error

### DIFF
--- a/lib/HTTP/Tinyish/Curl.pm
+++ b/lib/HTTP/Tinyish/Curl.pm
@@ -98,6 +98,9 @@ sub mirror {
     };
 
     if ($@ or $?) {
+        if ( -e $file ) {
+          unlink $file;
+        }
         return $self->internal_error($url, $@ || $error);
     }
 


### PR DESCRIPTION
remove empty file when curl fails to find file